### PR TITLE
add "react-router": "^6.0.0-alpha.3",

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
+    "react-router": "^6.0.0-alpha.3",
     "react-router-dom": "^6.0.0-alpha.3",
     "react-scripts": "3.4.1",
     "redux": "^4.0.5",


### PR DESCRIPTION
for some reason, "react-router": "^6.0.0-alpha.3" (line 25) was removed in last merge.  added back to unbreak app

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [x] There are no merge conflicts
