### PR TITLE
Fix calendar vertical scrollbar

### DIFF
--- a/src/components/events/view-events/CalendarView.js
+++ b/src/components/events/view-events/CalendarView.js
@@ -70,7 +70,7 @@ const CalendarView = () => {
   return (
     <div
       style={{
-        overflowY: "scroll",
+        overflowY: "auto",
         width: "100%",
         height: "80vh",
       }}


### PR DESCRIPTION
# Description

Set overflowY to auto.
Fixes #36 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Created enough events to require the scrollbar with the window 1/4 screen size, then set the CSS value `overflow-y: auto` and resized the screen vertically, confirming the scrollbar disappeared when there is enough room to display it all on screen.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
