### PR TITLE
Feature/address link url

### DIFF
--- a/src/components/events/view-events/EventDetails.js
+++ b/src/components/events/view-events/EventDetails.js
@@ -83,7 +83,7 @@ const EventDetails = () => {
         minute: "2-digit",
       })
       .toLowerCase();
-    parsedAddressURL = `https://www.google.com/maps/place/${event.address.replace(
+    parsedAddressURL = `https://www.google.com/maps/search/${event.address.replace(
       " ",
       "+"
     )}`;

--- a/src/components/events/view-events/EventDetails.js
+++ b/src/components/events/view-events/EventDetails.js
@@ -35,7 +35,8 @@ const EventDetails = () => {
     formattedDate,
     addStartTime,
     displayedEndTime,
-    addEndTime;
+    addEndTime,
+    parsedAddressURL;
 
   useEffect(() => {
     //get creator name when event loads.  This is a rough and inefficient way to do this, especially if there ends up being protected queries
@@ -82,6 +83,10 @@ const EventDetails = () => {
         minute: "2-digit",
       })
       .toLowerCase();
+    parsedAddressURL = `https://www.google.com/maps/place/${event.address.replace(
+      " ",
+      "+"
+    )}`;
   }
 
   return (
@@ -114,7 +119,13 @@ const EventDetails = () => {
             <span style={{ marginRight: "5px", verticalAlign: "middle" }}>
               <Icon height="20" icon={globeIcon} />
             </span>
-            {event.address}
+            <a
+              href={parsedAddressURL}
+              target="_blank"
+              style={{ color: "rgb(79, 79, 248)" }}
+            >
+              {event.address}
+            </a>
           </div>
           <div style={{ padding: "20px 0px 10px 0px" }}>
             <Typography variant="h5">


### PR DESCRIPTION
# Description

added address url link to google maps from view event (calendar) address field. 

One issue in relation to this new feature: create event form does not currently prevent simple or "bogus" addresses from posting to server, and backend interprets improper addresses as longitude: 2.110000 and latitude: -22.110000.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] unit test already in place
- [x] locally tested variety of addresses to see how the anchor tag link interprets it

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
