### PR TITLE
hotfix/change-static-url-to-use-env-var

### DIFF
--- a/src/components/account/PasswordChangePage.js
+++ b/src/components/account/PasswordChangePage.js
@@ -31,7 +31,7 @@ function ChangePassword () {
             password: passwordData.password
         };
 
-        const response = await axios.post("http://localhost:5100/auth/initialChangePassword", body);
+        const response = await axios.post(`${process.env.REACT_APP_BASE_URL}/auth/initialChangePassword`, body);
         push('/login');
         }catch(err){
             console.dir(err);


### PR DESCRIPTION
On the password change component the URL value which referenced the "initialChangePassword" endpoint need to be changed to reference the env var "REACT_APP_BASE_URL" in order for the deployed site to complete requests to that endpoint properly.

# Description

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
