### PR TITLE
Add-query_params-parameter-to-login-redirect-route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ function App() {
   return (
     <div className="app-container">
       <Switch>
-        <Route path="/login-redirect-url" component={LoginRedirect} />
+        <Route path="/login-redirect-url/:query_params" component={LoginRedirect} />
         <Route
           path="/generic-redirect/:redirect_path"
           component={GenericRedirect}

--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ function App() {
   return (
     <div className="app-container">
       <Switch>
-        <Route path="/login-redirect-url/:query_params" component={LoginRedirect} />
+        <Route path="/login-redirect-url?:query_params" component={LoginRedirect} />
         <Route
           path="/generic-redirect/:redirect_path"
           component={GenericRedirect}


### PR DESCRIPTION
On login for the deployed site Okta does not postpend the URL query string it is supposed to add in the case of a successful log which causes the redirect page to not redirect to the dashboard. In an attempt to solve this issue I am testing if explicitly adding a parameter to the React Router route for the login redirect page's Route component allows that to be added. This has to be testing against the deployed site as the local site does not suffer from the issue.

# Description


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
