### PR TITLE
fixed hard rerender force for status change

### DIFF
--- a/src/components/account/ProfileFields.js
+++ b/src/components/account/ProfileFields.js
@@ -97,7 +97,11 @@ const ProfileFields = (props) => {
         type="submit"
         disabled={props.submitting}
       >
-        {props.submitting ? <CircularProgress /> : "Submit"}
+        {props.submitting ? (
+          <CircularProgress style={{ color: "white" }} />
+        ) : (
+          "Submit"
+        )}
       </Button>
     </>
   );

--- a/src/components/dashboard/RecentEvents.js
+++ b/src/components/dashboard/RecentEvents.js
@@ -13,7 +13,6 @@ const RecentEvents = () => {
   const me = useSelector((state) => state.myUser);
   const eventList = useSelector((state) => state.eventList);
   const dispatch = useDispatch();
-  const update = useSelector((state) => state.update);
   const [isFetching, setIsFetching] = useState(true);
 
   useEffect(() => {
@@ -42,7 +41,7 @@ const RecentEvents = () => {
         setIsFetching(false);
       });
     // eslint-disable-next-line
-  }, [update]);
+  }, []);
   return (
     <div>
       <h2
@@ -57,7 +56,7 @@ const RecentEvents = () => {
         <div className="recent-events-container">
           {isFetching ? (
             <div style={{ textAlign: "center" }}>
-              <CircularProgress />
+              <CircularProgress style={{ color: "#58D573" }} />
             </div>
           ) : (
             !!eventList &&

--- a/src/components/events/single-event/FullEvent.js
+++ b/src/components/events/single-event/FullEvent.js
@@ -33,7 +33,7 @@ const FullEvent = ({ match }) => {
       .catch((err) => {
         console.log(err.message);
       });
-  }, []);
+  }, [dispatch, eventId]);
   return (
     <div
       className="single-event-container"

--- a/src/components/events/view-events/CalendarRow.js
+++ b/src/components/events/view-events/CalendarRow.js
@@ -3,22 +3,10 @@ import { useSelector, useDispatch } from "react-redux";
 import { makeActive } from "../../../utilities/actions";
 import { parseTime } from "../../../utilities/functions";
 
-const CalendarRow = ({ id, title, startTime, users, eventNum }) => {
+const CalendarRow = ({ id, title, startTime, eventNum, status }) => {
   const activeEvent = useSelector((state) => state.activeCalendarEvent);
-  const me = useSelector((state) => state.myUser);
   const dispatch = useDispatch();
-  let status;
 
-  //find status
-
-  if (users) {
-    const tempArray = users.filter((user) => `${user.id}` === `${me.id}`);
-    if (tempArray.length > 0) {
-      status = tempArray[0].status;
-    }
-  }
-
-  //time formatting
   const timeObject = parseTime(startTime, null);
 
   return (

--- a/src/components/events/view-events/CalendarView.js
+++ b/src/components/events/view-events/CalendarView.js
@@ -24,7 +24,6 @@ import { parseTime } from "../../../utilities/functions";
 
 const CalendarView = () => {
   const eventList = useSelector((state) => state.eventList);
-  const update = useSelector((state) => state.update); //seemingly because of how status is nested into events, there is no direct dispatch that will force re-render of this component without the use of update state. Unsure if this is the best approach.
   const selectedMonth = useSelector((state) => state.selectedMonth);
   const me = useSelector((state) => state.myUser);
   const dispatch = useDispatch();
@@ -54,17 +53,30 @@ const CalendarView = () => {
             parseTime(a.startTime, a.endTime).unixStart -
             parseTime(b.startTime, b.endTime).unixStart
         );
-
-        dispatch(getEventsSuccess(sortedByDate));
+        return sortedByDate;
+      })
+      .then((res) => {
+        const addStatus = res.map((ele) => {
+          return {
+            ...ele,
+            status: ele.users
+              ? ele.users.filter((user) => `${user.id}` === `${me.id}`)[0]
+                  .status
+              : null,
+          };
+        });
+        return addStatus;
+      })
+      .then((res) => {
+        dispatch(getEventsSuccess(res));
       })
       .catch((err) => {
         console.log(err.message);
       })
-      .then(function () {
+      .finally(function () {
         setIsLoading(false);
       });
-    // eslint-disable-next-line
-  }, [update]);
+  }, [dispatch, me.id]);
 
   return (
     <div
@@ -94,7 +106,7 @@ const CalendarView = () => {
           )
         ) : (
           <div style={{ textAlign: "center" }}>
-            <CircularProgress />
+            <CircularProgress style={{ color: "#58D573" }} />
           </div>
         )}
       </div>

--- a/src/components/events/view-events/EventDetails.js
+++ b/src/components/events/view-events/EventDetails.js
@@ -111,6 +111,7 @@ const EventDetails = () => {
               <a
                 href={parsedAddressURL}
                 target="_blank"
+                rel="noopener noreferrer"
                 style={{ color: "rgb(79, 79, 248)" }}
               >
                 {event.address}

--- a/src/components/events/view-events/StatusButton.js
+++ b/src/components/events/view-events/StatusButton.js
@@ -1,7 +1,7 @@
 import React from "react";
 import axios from "axios";
 import { useDispatch } from "react-redux";
-import { forceUpdate } from "../../../utilities/actions";
+import { changeStatus } from "../../../utilities/actions";
 import { buttonStyles } from "../../../styles";
 
 import { print } from "graphql";
@@ -19,9 +19,6 @@ const StatusButton = ({
   const dispatch = useDispatch();
 
   const updateStatus = (newStatus) => {
-    console.log(
-      `event_id: ${eventId}, user_id: ${userId}, status: ${newStatus}`
-    );
     axios
       .post(`${process.env.REACT_APP_BASE_URL}/graphql`, {
         query: print(UPDATE_INVITATION),
@@ -34,12 +31,11 @@ const StatusButton = ({
         },
       })
       .then((res) => {
-        setStatus(
-          res.data.data.updateInvitation.users.filter(
-            (u) => `${u.id}` === `${userId}`
-          )[0].status
-        );
-        dispatch(forceUpdate());
+        const newStatus = res.data.data.updateInvitation.users.filter(
+          (u) => `${u.id}` === `${userId}`
+        )[0].status;
+        setStatus(newStatus);
+        dispatch(changeStatus(eventId, newStatus));
       });
   };
   return (

--- a/src/utilities/actions/index.js
+++ b/src/utilities/actions/index.js
@@ -14,6 +14,7 @@ export const START_EVENT_EDIT = "START_EVENT_EDIT";
 export const CANCEL_EDIT = "CANCEL_EDIT";
 export const UPDATE_EVENT_SUCCESS = "UPDATE_EVENT_SUCCESS";
 export const SINGLE_EVENT_FETCH_SUCCESS = "SINGLE_EVENT_FETCH_SUCCESS";
+export const UPDATE_STATUS = "UPDATE_STATUS";
 
 export const getEventsSuccess = (events) => ({
   type: GET_EVENTS_SUCCESS,
@@ -31,6 +32,14 @@ export const setMonth = (type) => ({
 
 export const forceUpdate = () => ({
   type: UPDATE_STATE,
+});
+
+export const changeStatus = (eventId, newStatus) => ({
+  type: UPDATE_STATUS,
+  payload: {
+    eventId: eventId,
+    newStatus: newStatus,
+  },
 });
 
 export const changePage = () => ({

--- a/src/utilities/reducers/index.js
+++ b/src/utilities/reducers/index.js
@@ -15,6 +15,7 @@ import {
   CANCEL_EDIT,
   UPDATE_EVENT_SUCCESS,
   SINGLE_EVENT_FETCH_SUCCESS,
+  UPDATE_STATUS,
 } from "../actions";
 
 const initialDate = new Date();
@@ -75,6 +76,16 @@ export const rootReducer = (state = initialState, { type, payload }) => {
       return {
         ...state,
         update: !state.update,
+      };
+    case UPDATE_STATUS:
+      const newListWithChange = state.eventList.map((ele) => {
+        if (`${ele.id}` === `${payload.eventId}`)
+          ele.status = payload.newStatus;
+        return ele;
+      });
+      return {
+        ...state,
+        eventList: newListWithChange,
       };
     case CHANGE_PAGE:
       return {


### PR DESCRIPTION
# Description

To make the user experience better, I created this branch to remove the hard rerender force whenever status (going, maybe, not going) changes for a single event.  Before this fix, any change to a single status would rerender the entire page and fetch full event list from server, making a "blinking" effect of all event components as well as resetting the scroll back to the top.  After this fix, those issues should be resolved and will not fully rerender the entire page to update the status of a single event.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
