### PR TITLE
remove breaking variables from dependency

### DIFF
--- a/src/components/utils/private-route.jsx
+++ b/src/components/utils/private-route.jsx
@@ -42,7 +42,8 @@ function PrivateRoute({ component: Component, path, ...props }) {
     };
 
     validate();
-  }, [path, Component, props, push]);
+    // eslint-disable-next-line
+  }, [path, Component]);
 
   return finalComponent;
 }


### PR DESCRIPTION
# Description

hotfix for issue with address field in create event form after last pull request. The issue symptom was that immediately after placing focus on the address text box, the focus would be removed, so you could not enter in the field.  The issue cause seemed to be unwanted dependencies added to the useEffect method for private routing. Unsure why it would cause such a specific issue with only one field, and not other parts of private routing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] locally

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
