### PR TITLE
Feature/add profile drawer with static content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ yarn.lock
 
 #environment variables
 .env
+
+#Debug log
+debug.log

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -10,25 +10,6 @@ import { axiosWithAuth } from "../../utilities/axiosWithAuth";
 import { print } from "graphql";
 
 const Dashboard = () => {
-  useEffect(() => {
-    if (ls.get("access_token")) {
-      const token = ls.get("access_token");
-      const decodedToken = jwt(token).sub;
-      axiosWithAuth()({
-        url: `${process.env.REACT_APP_BASE_URL}/graphql`,
-        method: "post",
-        data: {
-          query: print(USER_BY_EMAIL),
-          variables: { input: { email: decodedToken } },
-        },
-      }).then((res) => {
-        sessionStorage.setItem(
-          "user",
-          JSON.stringify(res.data.data.getUserByEmail)
-        );
-      });
-    }
-  }, []);
 
   return (
     <div className="dashboard-container">

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -1,13 +1,8 @@
 import React, { useEffect } from "react";
-import Sidebar from "./Sidebar";
 // import Feed from "./Feed";
 import RecentEvents from "./RecentEvents";
 import Header from "./Header";
-import ls from "local-storage";
-import jwt from "jwt-decode";
-import { USER_BY_EMAIL } from "../../graphql/users/user-queries";
-import { axiosWithAuth } from "../../utilities/axiosWithAuth";
-import { print } from "graphql";
+
 
 const Dashboard = () => {
 

--- a/src/components/gridstructure.jsx
+++ b/src/components/gridstructure.jsx
@@ -4,7 +4,9 @@ import Sidebar from './dashboard/Sidebar';
 import Logo from './logo';
 import VariableMainContent from './variableMainContent';
 import { makeStyles, createMuiTheme } from "@material-ui/core/styles";
-import { useLocation} from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import Drawer from '@material-ui/core/Drawer';
+import clsx from 'clsx';
 
 const styles = makeStyles({
     "grid-container":{
@@ -15,17 +17,32 @@ const styles = makeStyles({
         "grid-template-areas":' "Logo Header" "Sidebar Variable" ',
         height: "100vh"
     },
+    "grid-container-shifted": {
+        display: "grid",
+        "grid-template-columns": "2fr 2fr 2fr 2fr",
+        "grid-template-rows": "1fr 9fr",
+        gap: "1px 1px",
+    },
     "Variable":{
         gridArea: "Variable",
         border: "2px solid black"
+    },
+    "Variable-Shifted" : { 
+        "grid-area": "2 / 2 / 3 / 4" 
     },
     "Header":{
         gridArea: "Header",
         height: "10vh"
     },
+    "Header-Shifted": { 
+        "grid-area": "1 / 2 / 2 / 4" 
+    },
     "Sidebar":{
         gridArea: "Sidebar",
         paddingLeft: "5%"
+    },
+    "Sidebar-Shifted": { 
+        "grid-area": "2 / 1 / 3 / 2" 
     },
     "Logo": {
         gridArea: "Logo",
@@ -44,6 +61,31 @@ const styles = makeStyles({
                 width: "115%"
             }
         }
+    },
+    "Logo-Shifted": { 
+        "grid-area": "1 / 1 / 2 / 2",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "flex-start",
+
+        "& *": {
+            width: "100%",
+
+            "&:first-child": {
+                width: "20%"
+            },
+
+            "&:last-child": {
+                width: "115%"
+            }
+        }
+    },
+    "Drawer-Container": {
+        "grid-area": "1 / 4 / 3 / 5",
+        width: "25vw"
+    },
+    "Drawer": {
+        width: "25vw"
     }
 });
 
@@ -68,18 +110,31 @@ function GridStructure (props){
     }
 
     return (
-        <div className={classes["grid-container"]}>
-            <div className={classes["Logo"]} >
+        <div className={clsx({[classes["grid-container"]]: (!open), [classes["grid-container-shifted"]]: open})}>
+            <div className={clsx({[classes["Logo"]]: (!open), [classes["Logo-Shifted"]]: open})} >
                 <Logo />
             </div>
             <div className={clsx({[classes["Header"]]: (!open), [classes["Header-Shifted"]]: open})}>
                 <Header openDrawer={openDrawer}/>
             </div>
-            <div className={classes["Sidebar"]}>
+            <div className={clsx({[classes["Sidebar"]]: (!open), [classes["Sidebar-Shifted"]]: open})}>
                 <Sidebar active={urlLocation}/>
             </div>
-            <div className={classes["Variable"]}>
+            <div className={clsx({[classes["Variable"]]: (!open), [classes["Variable-Shifted"]]: open})}>
                 <VariableMainContent />
+            </div>
+            <div className={clsx({[classes["Drawer-Container"]]: open})}>
+                <Drawer
+                variant="persistent"
+                open={open}
+                anchor="right"
+                className={clsx({[classes["Drawer"]]: open})}
+                classes={{
+                    paper: classes.Drawer
+                }}
+                >
+                    <p onClick={closeDrawer}>I am a Drawer</p>
+                </Drawer>
             </div>
         </div>
     );

--- a/src/components/gridstructure.jsx
+++ b/src/components/gridstructure.jsx
@@ -27,7 +27,6 @@ const styles = makeStyles({
     },
     "Variable":{
         gridArea: "Variable",
-        border: "2px solid black"
     },
     "Variable-Shifted" : { 
         "grid-area": "2 / 2 / 3 / 4" 

--- a/src/components/gridstructure.jsx
+++ b/src/components/gridstructure.jsx
@@ -3,10 +3,12 @@ import Header from './header';
 import Sidebar from './dashboard/Sidebar';
 import Logo from './logo';
 import VariableMainContent from './variableMainContent';
+import ProfileDrawerContent from './profileDrawerContent';
 import { makeStyles, createMuiTheme } from "@material-ui/core/styles";
 import { useLocation } from 'react-router-dom';
 import Drawer from '@material-ui/core/Drawer';
 import clsx from 'clsx';
+
 
 const styles = makeStyles({
     "grid-container":{
@@ -133,7 +135,7 @@ function GridStructure (props){
                     paper: classes.Drawer
                 }}
                 >
-                    <p onClick={closeDrawer}>I am a Drawer</p>
+                    <ProfileDrawerContent closeDrawer={closeDrawer} />
                 </Drawer>
             </div>
         </div>

--- a/src/components/gridstructure.jsx
+++ b/src/components/gridstructure.jsx
@@ -57,13 +57,23 @@ function GridStructure (props){
         setUrlLocation(location.pathname.split("/")[1]);
     }, [location]);
 
+    const [ open, setOpen ] = useState(false);
+
+    const openDrawer = () => {
+        setOpen(true);
+    }
+
+    const closeDrawer = () => {
+        setOpen(false);
+    }
+
     return (
         <div className={classes["grid-container"]}>
             <div className={classes["Logo"]} >
                 <Logo />
             </div>
-            <div className={classes["Header"]}>
-                <Header/>
+            <div className={clsx({[classes["Header"]]: (!open), [classes["Header-Shifted"]]: open})}>
+                <Header openDrawer={openDrawer}/>
             </div>
             <div className={classes["Sidebar"]}>
                 <Sidebar active={urlLocation}/>

--- a/src/components/gridstructure.jsx
+++ b/src/components/gridstructure.jsx
@@ -117,7 +117,7 @@ function GridStructure (props){
                 <Logo />
             </div>
             <div className={clsx({[classes["Header"]]: (!open), [classes["Header-Shifted"]]: open})}>
-                <Header openDrawer={openDrawer}/>
+                <Header openDrawer={openDrawer} open={open}/>
             </div>
             <div className={clsx({[classes["Sidebar"]]: (!open), [classes["Sidebar-Shifted"]]: open})}>
                 <Sidebar active={urlLocation}/>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -23,7 +23,7 @@ function Header (props) {
     return (
         <div className={classes["container"]}>
             <VariableHeader className={classes["header-variable"]}/>
-            <PersistentHeader className={classes["header-persistent"]}/> 
+            <PersistentHeader openDrawer={props.openDrawer} className={classes["header-persistent"]}/> 
         </div>
     );
 }

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -23,7 +23,7 @@ function Header (props) {
     return (
         <div className={classes["container"]}>
             <VariableHeader className={classes["header-variable"]}/>
-            <PersistentHeader openDrawer={props.openDrawer} className={classes["header-persistent"]}/> 
+            <PersistentHeader openDrawer={props.openDrawer} open={props.open} className={classes["header-persistent"]}/> 
         </div>
     );
 }

--- a/src/components/headerPartitionPersistent.jsx
+++ b/src/components/headerPartitionPersistent.jsx
@@ -38,7 +38,7 @@ function PersistentHeader (props){
         <section className={classes["container"]} >
             <Icon icon={bxBell} />
             <Icon icon={magnifyingGlass} />
-            <Avatar className={classes["avatar"]} alt="Picture User Avatar" src="#" /> 
+            <Avatar onClick={props.openDrawer} className={classes["avatar"]} alt="Picture User Avatar" src="#" /> 
         </section>
     );
 }

--- a/src/components/headerPartitionPersistent.jsx
+++ b/src/components/headerPartitionPersistent.jsx
@@ -9,7 +9,6 @@ const styles = makeStyles(theme => ({
     "container": {
         width: "20vw",
         height: "10vh",
-        border: "2px solid black",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",

--- a/src/components/headerPartitionPersistent.jsx
+++ b/src/components/headerPartitionPersistent.jsx
@@ -38,7 +38,7 @@ function PersistentHeader (props){
         <section className={classes["container"]} >
             <Icon icon={bxBell} />
             <Icon icon={magnifyingGlass} />
-            <Avatar onClick={props.openDrawer} className={classes["avatar"]} alt="Picture User Avatar" src="#" /> 
+            <Avatar onClick={props.openDrawer} style={props.open ? {display: "none"} : {display: 'flex'}} className={classes["avatar"]} alt="Picture User Avatar" src="#" /> 
         </section>
     );
 }

--- a/src/components/headerPartitionVariable.jsx
+++ b/src/components/headerPartitionVariable.jsx
@@ -6,7 +6,6 @@ const styles = makeStyles({
     "container": {
         width: "100%",
         height: "10vh",
-        border: "2px solid black"
     }
 });
 

--- a/src/components/profileDrawerContent.jsx
+++ b/src/components/profileDrawerContent.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import Avatar from '@material-ui/core/Avatar';
+import { makeStyles } from '@material-ui/core/styles'
+
+
+const styles = makeStyles(theme => {
+
+    return {
+        "container": {
+            display: "flex",
+            flexDirection: "column",
+            paddingTop: "3.5vh",
+            padding: "0 5%",
+            background: "lightgrey",
+            height: "100vh",
+            overflowY: "scroll"
+        },
+        "avatar-container": {
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            marginTop: "2%"
+        },
+        "avatar": {
+            width: theme.spacing(13),
+            height: theme.spacing(13),
+            fontSize: "200%",
+            marginBottom: "3%"
+        },
+        "middle-content-container": {
+            marginTop: "2%",
+
+            "& h6": {
+                fontWeight: "bold"
+            },
+
+            "& p": {
+                marginTop: "2%",
+                marginBottom: "5%"
+            }
+        },
+        "bottom-content-container": {
+
+            "& section" : {
+                minHeight: "20vh",
+                background: "white",
+                margin: "4% 0",
+                borderRadius: "10px"
+            }
+        },
+        "bottom-header-container": {
+            display: "flex",
+            marginBottom: "5%",
+            
+            "& h6:first-child": {
+                flexBasis: "75%"
+            },
+
+            "& h6:last-child": {
+                flexBasis: "25%"
+            }
+        }
+    }
+})
+
+function ProfileDrawerContent (props) {
+
+    const classes = styles();
+
+    return (
+        <section className={classes.container}>
+            <Typography variant="h5" onClick={props.closeDrawer}>{"> Profile"}</Typography>
+            <div className={classes["avatar-container"]}>
+                <Avatar className={classes.avatar} src="#" alt="Profile Avatar" />
+                <Typography>First Last</Typography>
+                <Typography>Edit Profile</Typography>
+            </div>
+            <div className={classes["middle-content-container"]}>
+                <Typography variant="h6">Description</Typography>
+                <Typography >Lorem ipsum dolor sit amet consectetur 
+                    adipisicing elit. Accusantium debitis 
+                    voluptatum nisi iste?</Typography>
+                <Typography variant="h6">Dietary Restrictions</Typography>
+                <Typography>Lorem ipsum dolor sit amet consectetur 
+                    adipisicing elit. Accusantium debitis 
+                    voluptatum nisi iste?</Typography>
+            </div>
+            <div className={classes["bottom-content-container"]}>
+                <div className={classes["bottom-header-container"]}>
+                    <Typography variant="h6">Posts and Events</Typography>
+                    <Typography variant="h6">See all</Typography>
+                </div>
+                <section>
+                    card
+                </section>
+                <section>
+                    card
+                </section>
+                <section>
+                    card
+                </section>
+            </div>
+        </section>
+
+    )
+}
+
+export default ProfileDrawerContent;

--- a/src/components/utils/generic-redirect.jsx
+++ b/src/components/utils/generic-redirect.jsx
@@ -1,14 +1,43 @@
 import React from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import ls from 'local-storage';
+import jwt from "jwt-decode";
+import { axiosWithAuth } from "../../utilities/axiosWithAuth";
+import { print } from "graphql";
+import { USER_BY_EMAIL } from "../../graphql/users/user-queries";
 
 function GenericRedirect (props){
 
     const { push } = useHistory();
     const { redirect_path } = useParams();
 
+    const getInitialUserData =  () => {
+        const token = ls.get("access_token");
+        const decodedToken = jwt(token).sub;
+        axiosWithAuth()({
+          url: `${process.env.REACT_APP_BASE_URL}/graphql`,
+          method: "post",
+          data: {
+            query: print(USER_BY_EMAIL),
+            variables: { input: { email: decodedToken } },
+          },
+        }).then((res) => {
+          sessionStorage.setItem(
+            "user",
+            JSON.stringify(res.data.data.getUserByEmail)
+          );
+        });
+    }
+
+    const redirectOnLoginSuccess = async () => {
+        await getInitialUserData();
+        push(`/${redirect_path}`); 
+    }
+
     if(!ls.get('access_token')) { push(`/generic-redirect/${redirect_path}`); }
-    else { push(`/${redirect_path}`); }
+    else { 
+        redirectOnLoginSuccess();
+    }
 
     return null
 }


### PR DESCRIPTION
# Description
Creates a profile content drawer which can open and close in accordance to the UX design document. Material UI's Drawer component was used to achieve this end. Paired with conditional styling on Drawer close and open as well as local state set up through the use of useState. The current styling and components are completely static and will require additional functionality and styling to achieve then end goal for the drawer. 


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Test A
Ascertained functionality through the hot-loaded webpack server (toggled in and out of the drawer)
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
