### PR TITLE
bugfix/create-event-edit-mode

### DIFF
--- a/src/components/events/create-event/FormContainer.js
+++ b/src/components/events/create-event/FormContainer.js
@@ -72,7 +72,7 @@ const FormContainer = () => {
       const savedAllergens = eventToEdit.allergenWarnings;
       const savedDietWarnings = eventToEdit.dietaryWarnings;
 
-      if (savedHashtags && Object.keys(savedModifiers).length !== 0) {
+      if (savedModifiers && Object.keys(savedModifiers).length !== 0) {
         restoreSavedModifiers(
           modifierData,
           savedModifiers.modifiers,
@@ -80,7 +80,7 @@ const FormContainer = () => {
         );
       }
 
-      if (savedModifiers && Object.keys(savedHashtags).length !== 0) {
+      if (savedHashtags && Object.keys(savedHashtags).length !== 0) {
         setHashtags(savedHashtags.hashtags);
       }
 


### PR DESCRIPTION
#Description 
Noticed that the form would break when editing events created before the new dietary and allergy warnings fields were added because those values would come back as null, instead of an empty JSON object. I added a quick fix to check for null values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
Locally.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
