### PR TITLE
Set yarn network-timeout to 10 minutes.

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000


### PR DESCRIPTION
# Description

https://github.com/yarnpkg/yarn/issues/5540#issuecomment-374069461

Fixes yarn dependency network problem:
```
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
error An unexpected error occurred: "https://registry.yarnpkg.com/@iconify/icons-ic/-/icons-ic-1.0.12.tgz: ESOCKETTIMEDOUT".
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Installing yarn dependencies actually works now
