### PR TITLE
feature/move-date/time-functionality-into-parseTime-function

### DIFF
--- a/src/components/dashboard/EventButtonModal.js
+++ b/src/components/dashboard/EventButtonModal.js
@@ -20,7 +20,7 @@ import {
   startEventEdit,
 } from "../../utilities/actions";
 import { useLocation } from "react-router-dom";
-import { convertTimeAndDate } from "../../utilities/functions";
+import { parseTime } from "../../utilities/functions";
 
 import WarnRemoveModal from "./WarnRemoveModal";
 
@@ -34,6 +34,7 @@ const EventButtonModal = ({ eventId, userId }) => {
   const modalClasses = modalStyles();
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
+  const timeObject = parseTime(currentEvent.startTime, currentEvent.endTime);
 
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
@@ -121,12 +122,9 @@ const EventButtonModal = ({ eventId, userId }) => {
                             onClick={() => {
                               /* had to add date to eventToEdit object and convert start/end times here for editing 
                                 mode to allow moment functions to finish converting before the form rendered */
-                              const convertForEdit = convertTimeAndDate(
-                                currentEvent
-                              );
-                              currentEvent.date = convertForEdit.date;
-                              currentEvent.startTime = convertForEdit.startTime;
-                              currentEvent.endTime = convertForEdit.endTime;
+                              currentEvent.date = timeObject.formDate;
+                              currentEvent.startTime = timeObject.formStartTime;
+                              currentEvent.endTime = timeObject.formEndTime;
                               dispatch(startEventEdit(currentEvent));
                               history.push("/create-event");
                             }}

--- a/src/utilities/functions/functions.test.js
+++ b/src/utilities/functions/functions.test.js
@@ -40,13 +40,6 @@ describe("Test functions index.js file", () => {
     expect(convertTime("23:30:00")).toBe("11:30PM");
   });
 
-  // test("date/time strings will be converted to object with date, startTime, and endTime key/value pairs", () => {
-  //   const convertedTimes = convertTimeAndDate(eventTimes);
-  //   expect(convertedTimes.date).toBe("2020-06-26");
-  //   expect(convertedTimes.startTime).toEqual("17:30:00");
-  //   expect(convertedTimes.endTime).toEqual("22:30:00");
-  // });
-
   test("test if modifiers are restored with icon added back", () => {
     const restoredModifiers = restoreSavedModifiers(
       modifierData,

--- a/src/utilities/functions/index.js
+++ b/src/utilities/functions/index.js
@@ -68,14 +68,9 @@ export const parseTime = (start, end) => ({
   startTime: moment(parseInt(start)).format("h:mm a"),
   endTime: moment(parseInt(end)).format("h:mm a"),
   unixStart: start,
-});
-
-export const convertTimeAndDate = (event) => ({
-  date: moment(parseInt(event.startTime)).format("YYYY-MM-DD"),
-  startTime: moment(parseInt(event.startTime)).format("HH:mm:ss"),
-  endTime: event.endTime
-    ? moment(parseInt(event.endTime)).format("HH:mm:ss")
-    : "",
+  formDate: moment(parseInt(start)).format("YYYY-MM-DD"),
+  formStartTime: moment(parseInt(start)).format("HH:mm:ss"),
+  formEndTime: end ? moment(parseInt(end)).format("HH:mm:ss") : "",
 });
 
 export const isEventFavorite = (arr, id) => {


### PR DESCRIPTION
# Description
As discussed in slack, I moved the original date/time function properties into the parseTime function to remove redundant function and test. Also, updated the onClick to use the parseTime instead when converting time/date for event that is being edited.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Locally

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
