### PR TITLE
bugfux/fit-event-pages-2,3,4-into-100vh

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -308,7 +308,6 @@ a {
 .createForm {
   display: flex;
   flex-direction: column;
-  margin: 20px 0;
   width: 100%;
 }
 
@@ -550,9 +549,8 @@ a {
 .createFormButtonDiv {
   display: flex;
   justify-content: flex-end;
-  margin-top: 40px;
   margin-right: 1%;
-  margin-bottom: 40px;
+  margin-bottom: 20px;
 }
 
 @media (max-width: 1000px) {

--- a/src/components/events/create-event/EventCard.js
+++ b/src/components/events/create-event/EventCard.js
@@ -21,7 +21,6 @@ const EventCard = () => {
         border: "2px solid #F3F3F3",
         boxShadow: "0px 4px 15px rgba(179, 179, 179, 0.1)",
         borderRadius: "25px",
-        marginTop: "40px",
         padding: "30px",
       }}
     >

--- a/src/components/events/create-event/FormPageThree.js
+++ b/src/components/events/create-event/FormPageThree.js
@@ -35,7 +35,7 @@ const FormPageThree = ({
           border: "2px solid #F3F3F3",
           boxShadow: "0px 4px 15px rgba(179, 179, 179, 0.1)",
           borderRadius: "25px",
-          marginTop: "40px",
+          marginTop: "10px",
           padding: "30px",
         }}
       >
@@ -132,7 +132,7 @@ const FormPageThree = ({
           fontSize: "1.8rem",
           fontWeight: "500",
           color: "#1A0F2C",
-          margin: "60px 0",
+          margin: "20px 0",
         }}
       >
         Double check if your event details are correct. Once finished, click

--- a/src/components/events/create-event/FormPageTwo.js
+++ b/src/components/events/create-event/FormPageTwo.js
@@ -60,7 +60,7 @@ const FormPageTwo = ({
           removeHashtag={removeHashtag}
         />
         <div>
-          <Typography style={{ margin: "25px 0" }}>
+          <Typography style={{ margin: "10px 0" }}>
             Pick modifiers for your event.
           </Typography>
           <div style={{ display: "flex", width: "100%", flexFlow: "row wrap" }}>

--- a/src/components/events/create-event/SearchFriends.js
+++ b/src/components/events/create-event/SearchFriends.js
@@ -84,7 +84,7 @@ const SearchFriends = () => {
         border: "2px solid #F3F3F3",
         boxShadow: "0px 4px 15px rgba(179, 179, 179, 0.1)",
         borderRadius: "25px",
-        marginTop: "40px",
+        marginTop: "15px",
         marginBottom: "120px",
         padding: "30px",
       }}


### PR DESCRIPTION
#Description 
I adjusted the margins on pages 2, 3, 4 of the create event form, so the full page will fit into 100vh on first render like page 1. This obviously won't apply once modifiers are added or searching for friends.

Fixes #116 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Locally 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
